### PR TITLE
update dependencies, use docusaurus beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.4.3",
-    "@docusaurus/preset-classic": "2.4.3",
-    "@mdx-js/react": "^1.6.21",
+    "@docusaurus/core": "3.0.0-beta.0",
+    "@docusaurus/preset-classic": "3.0.0-beta.0",
+    "@mdx-js/react": "^2.3.0",
     "@svgr/webpack": "^8.1.0",
     "clsx": "^2.0.0",
     "file-loader": "^6.2.0",
-    "prism-react-renderer": "^2.0.6",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "prism-react-renderer": "^2.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "url-loader": "^4.1.1"
   },
   "browserslist": {


### PR DESCRIPTION
if we are to consider the pull requests #37 and #38 as requirements for us, we gotta use the canary or beta release of docusaurus. i've chosen to use the beta version, but we'll have to make sure we switch to a stable release once 3.0 is released.

thankfully this app is so small that checking that everything works takes like 30 seconds.