### PR TITLE
Update from intern to ansatt url

### DIFF
--- a/docs/behandlingskatalog.md
+++ b/docs/behandlingskatalog.md
@@ -285,7 +285,7 @@ Alle i NAV har både lese- og skrivetilgang til løsningen i preprod:[Behandling
 * [Swagger API (Test)](https://behandlingskatalog-backend.intern.dev.nav.no/swagger-ui/index.html)
 
 **Datasett**  
-* [Behandlingskatalogen datasett](https://data.intern.nav.no/search?text=behandlingskatalogen&preferredType=dataproduct) (mangelfullt, under arbeid)
+* [Behandlingskatalogen datasett](https://data.ansatt.nav.no/search?text=behandlingskatalogen&preferredType=dataproduct) (mangelfullt, under arbeid)
 
 **Tilgang og headers**  
 API er åpent for lesing for alle Nav-ansatte på en Nav-innrullert enhet, men eksponeres ikke eksternt utenfor Nav. 

--- a/docs/etterlevelse.md
+++ b/docs/etterlevelse.md
@@ -43,8 +43,8 @@ Produktet adresserer:
 * [Swagger API (Test)](https://etterlevelse-api.dev.intern.nav.no/swagger-ui/index.html)
 
 ### Datasett
-* [Etterlevelseskrav i Metabase](https://metabase.intern.nav.no/browse/95-teamdatajegerne-etterlevelse-krav)
-* [Etterlevelsesdokumentasjon i Metabase](https://metabase.intern.nav.no/browse/96-teamdatajegerne-etterlevelse-etterlevelse)
+* [Etterlevelseskrav i Metabase](https://metabase.ansatt.nav.no/browse/95-teamdatajegerne-etterlevelse-krav)
+* [Etterlevelsesdokumentasjon i Metabase](https://metabase.ansatt.nav.no/browse/96-teamdatajegerne-etterlevelse-etterlevelse)
 
 ### Tilgang og headers
 API er åpent for lesing for alle Nav-ansatte på en Nav-innrullert enhet, men eksponeres ikke eksternt utenfor Nav. 


### PR DESCRIPTION
The redirect from intern.nav.no to ansatt.nav.no for this domain will stop working shortly.